### PR TITLE
Fix YearMonthSelector picker icon in read-only mode

### DIFF
--- a/YearMonthSelector/YearMonthSelector.vue
+++ b/YearMonthSelector/YearMonthSelector.vue
@@ -147,7 +147,8 @@ onMounted(() => {
       <div
         i-formkit:month
         class="picker-icon"
-        @mousedown="handlePickerIconClick"
+        :class="{ 'cursor-pointer': !readonly }"
+        @mousedown="!readonly && handlePickerIconClick($event)"
         @click.stop.prevent
       />
     </template>
@@ -156,6 +157,6 @@ onMounted(() => {
 
 <style lang="scss" scoped>
 .picker-icon {
-  @apply cursor-pointer color-ca m-x-2 h-5.5 w-5.5;
+  @apply color-ca m-x-2 h-5.5 w-5.5;
 }
 </style>

--- a/YearMonthSelector/YearMonthSelector.vue
+++ b/YearMonthSelector/YearMonthSelector.vue
@@ -43,6 +43,10 @@ const isPickerActive = ref(false)
 const pickerState = ref('hide')
 
 function handlePickerIconClick(ev: MouseEvent) {
+  if (props.readonly || props.disabled) {
+    return
+  }
+
   if (isPickerActive.value) {
     ev.preventDefault()
     ev.stopPropagation()
@@ -148,7 +152,7 @@ onMounted(() => {
         i-formkit:month
         class="picker-icon"
         :class="{ 'cursor-pointer': !readonly }"
-        @mousedown="!readonly && handlePickerIconClick($event)"
+        @mousedown="handlePickerIconClick"
         @click.stop.prevent
       />
     </template>


### PR DESCRIPTION
Adding read-only mode is not enough for the component `YearMonthSelector.vue` user can bypass the read-only mode by clicking on the icon.  